### PR TITLE
Run tests with rustvmm/dev:v3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "build-gnu-arm"
@@ -24,7 +24,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "build-musl-x86"
@@ -37,7 +37,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "build-musl-arm"
@@ -50,7 +50,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "style"
@@ -62,7 +62,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "unittests-gnu-x86"
@@ -76,7 +76,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "unittests-gnu-arm"
@@ -90,7 +90,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "unittests-musl-x86"
@@ -104,7 +104,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "unittests-musl-arm"
@@ -118,7 +118,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "clippy-x86"
@@ -131,7 +131,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "clippy-arm"
@@ -144,7 +144,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "check-warnings-x86"
@@ -158,7 +158,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "check-warnings-arm"
@@ -172,7 +172,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 
   - label: "coverage-x86"
@@ -186,5 +186,5 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
           always-pull: true
 ```
 
@@ -105,7 +105,7 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v2"
+          image: "rustvmm/dev:v3"
 always-pull: true
 ```
 
@@ -188,7 +188,7 @@ docker run --device=/dev/kvm \
            -it \
            --security-opt seccomp=unconfined \
            --volume $(pwd)/kvm-ioctls:/kvm-ioctls \
-           rustvmm/dev:v2
+           rustvmm/dev:v3
 cd kvm-ioctls/
 pytest --profile=devel tests/test_coverage.py
 ```


### PR DESCRIPTION
The container now runs Rust 1.35. This is needed as versions 1.34.0
up to 1.34.2 (which is the first one to include a fix) have a security
vulnerability.

For details check the CVE: https://www.cvedetails.com/cve/CVE-2019-12083/