### PR TITLE
buildkite: Move to the rustvmm/dev v4 container

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -134,19 +134,6 @@ steps:
           image: "rustvmm/dev:v3"
           always-pull: true
 
-  - label: "clippy-arm"
-    commands:
-     - cargo clippy --all -- -D warnings
-    retry:
-      automatic: false
-    agents:
-      platform: arm.metal
-      os: linux
-    plugins:
-      - docker#v3.0.1:
-          image: "rustvmm/dev:v3"
-          always-pull: true
-
   - label: "check-warnings-x86"
     commands:
       - RUSTFLAGS="-D warnings" cargo check --all-targets

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "build-gnu-arm"
@@ -24,7 +24,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "build-musl-x86"
@@ -37,7 +37,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "build-musl-arm"
@@ -50,7 +50,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "style"
@@ -62,7 +62,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "unittests-gnu-x86"
@@ -76,7 +76,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "unittests-gnu-arm"
@@ -90,7 +90,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "unittests-musl-x86"
@@ -104,7 +104,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "unittests-musl-arm"
@@ -118,7 +118,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "clippy-x86"
@@ -131,7 +131,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "check-warnings-x86"
@@ -145,7 +145,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "check-warnings-arm"
@@ -159,7 +159,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true
 
   - label: "coverage-x86"
@@ -173,5 +173,5 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v3"
+          image: "rustvmm/dev:v4"
           always-pull: true


### PR DESCRIPTION
In order to bump our CI Rust toolchain to 1.39.0.

As the 1.39.0 aarch64 toolchain do not support the `clippy` component, we had to disable the `clippy` test on ARM.
    
Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>