### PR TITLE
skip coverage-arm test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -179,6 +179,7 @@ steps:
   - label: "coverage-arm"
     commands:
       - pytest rust-vmm-ci/integration_tests/test_coverage.py
+    skip: "Currently this test is very unreliable. Kcov on aarch64 needs fixing."
     retry:
       automatic: false
     agents:


### PR DESCRIPTION
Right now this test is super unreliable and pretty much blocks every
other PR. Skip it for now until we fix kcov.

Related to: https://github.com/rust-vmm/rust-vmm-ci/issues/18