### PR TITLE
run cargo check on all features

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,7 +136,7 @@ steps:
 
   - label: "check-warnings-x86"
     commands:
-      - RUSTFLAGS="-D warnings" cargo check --all-targets
+      - RUSTFLAGS="-D warnings" cargo check --all-targets --all-features
     retry:
       automatic: false
     agents:
@@ -150,7 +150,7 @@ steps:
 
   - label: "check-warnings-arm"
     command:
-     - RUSTFLAGS="-D warnings" cargo check --all-targets
+     - RUSTFLAGS="-D warnings" cargo check --all-targets --all-features
     retry:
       automatic: false
     agents:


### PR DESCRIPTION
Warnings should be checked by custom pipelines. The common
pipeline should check warnings on all features instead.

