### PR TITLE
Fix commit format test

### DIFF
--- a/integration_tests/test_benchmark.py
+++ b/integration_tests/test_benchmark.py
@@ -22,6 +22,10 @@ def test_bench():
 
     # Move to upstream tip.
     subprocess.run(
+        "git fetch {} {}".format(REMOTE, BRANCH),
+        shell=True, check=True
+    )
+    subprocess.run(
         "git checkout {}/{}".format(REMOTE, BRANCH),
         shell=True, check=True
     )

--- a/integration_tests/test_commit_format.py
+++ b/integration_tests/test_commit_format.py
@@ -3,12 +3,14 @@
 """Test the commit message format."""
 
 import os
+import subprocess
 
 from utils import get_cmd_output
 
 COMMIT_TITLE_MAX_LEN = 50
 COMMIT_BODY_LINE_MAX_LEN = 72
 BASE_BRANCH = os.environ['BUILDKITE_PULL_REQUEST_BASE_BRANCH']
+BASE_REPO = os.environ['BUILDKITE_REPO']
 
 
 def test_commit_format():
@@ -19,10 +21,13 @@ def test_commit_format():
     [https://www.midori-global.com/blog/2018/04/02/git-50-72-rule]
     and if commits are signed.
     """
+    # Fetch the upstream repository.
+    fetch_base_cmd = "git fetch {} {}".format(BASE_REPO, BASE_BRANCH)
+    subprocess.run(fetch_base_cmd, shell=True, check=True)
     # Get hashes of PR's commits in their abbreviated form for
     # a prettier printing.
     shas_cmd = "git log --no-merges --pretty=%h --no-decorate " \
-               "{}..HEAD".format(BASE_BRANCH)
+               "FETCH_HEAD..HEAD"
     shas = get_cmd_output(shas_cmd)
 
     for sha in shas.split():


### PR DESCRIPTION
Even though `origin` was pointing to the right upstream repo, the repo wasn't fetched and because of that, we ended comparing HEAD with a wrong master. The commit format test for the following dummy PR: https://github.com/rust-vmm/kvm-ioctls/pull/109 is passing now (which is the expected behavior).

Also, it looks like we had the same problem in the benchmark test. I fixed that too, but this change (and basically the entire test) can be properly tested in a PR that actually uses it (for example https://github.com/rust-vmm/linux-loader/pull/46). Nevertheless, I expect fetching is necessary here too.