### PR TITLE
Coverage test: keep stdin open

### DIFF
--- a/integration_tests/test_coverage.py
+++ b/integration_tests/test_coverage.py
@@ -79,7 +79,9 @@ def _get_current_coverage(coverage_config):
         exclude_pattern
     )
 
-    subprocess.run(kcov_cmd, shell=True, check=True)
+    # Pytest closes stdin by default, but some tests might need it to be open.
+    # In the future, should the need arise, we can feed custom data to stdin.
+    subprocess.run(kcov_cmd, shell=True, check=True, input=b'')
 
     # Read the coverage reported by kcov.
     coverage_file = os.path.join(kcov_output_dir, 'index.js')


### PR DESCRIPTION
Pytest closes stdin by default, so any processes spawned from it won't have it. As some tests in various rust-vmm crates might need stdin to be open, we mock it with a (currently empty) byte stream, which we can extend in the future.
