### PR TITLE
add support for workspace tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,7 @@ steps:
 
   - label: "unittests-gnu-x86"
     commands:
-     - cargo test --all-features
+     - cargo test --all-features --workspace
     retry:
       automatic: false
     agents:
@@ -81,7 +81,7 @@ steps:
 
   - label: "unittests-gnu-arm"
     commands:
-     - cargo test --all-features
+     - cargo test --all-features --workspace
     retry:
       automatic: false
     agents:
@@ -95,7 +95,7 @@ steps:
 
   - label: "unittests-musl-x86"
     command:
-     - cargo test --all-features --target x86_64-unknown-linux-musl
+     - cargo test --all-features --workspace --target x86_64-unknown-linux-musl
     retry:
       automatic: false
     agents:
@@ -109,7 +109,7 @@ steps:
 
   - label: "unittests-musl-arm"
     command:
-     - cargo test --all-features --target aarch64-unknown-linux-musl
+     - cargo test --all-features --workspace --target aarch64-unknown-linux-musl
     retry:
       automatic: false
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,7 +136,7 @@ steps:
 
   - label: "check-warnings-x86"
     commands:
-      - RUSTFLAGS="-D warnings" cargo check --all-targets --all-features
+      - RUSTFLAGS="-D warnings" cargo check --all-targets --all-features --workspace
     retry:
       automatic: false
     agents:
@@ -150,7 +150,7 @@ steps:
 
   - label: "check-warnings-arm"
     command:
-     - RUSTFLAGS="-D warnings" cargo check --all-targets --all-features
+     - RUSTFLAGS="-D warnings" cargo check --all-targets --all-features --workspace
     retry:
       automatic: false
     agents:

--- a/integration_tests/test_commit_format.py
+++ b/integration_tests/test_commit_format.py
@@ -35,15 +35,15 @@ def test_commit_format():
         message = get_cmd_output(message_cmd)
         message_lines = message.split("\n")
         assert len(message_lines) >= 3,\
-            "The commit should contain at least 3 lines: title, blank " \
-            "line and a sign-off one. Please check: " \
-            "https://www.midori-global.com/blog/2018/04/02/git-50-72-rule."
+            "The commit '{}' should contain at least 3 lines: title, " \
+            "blank line and a sign-off one. Please check: " \
+            "https://www.midori-global.com/blog/2018/04/02/git-50-72-rule."\
+            .format(sha)
         title = message_lines[0]
-        assert message_lines[1] == "", "Commit title is divided into " \
-                                       "multiple lines. Please keep it " \
-                                       "one line long and make sure you " \
-                                       "add a blank line between title " \
-                                       "and description."
+        assert message_lines[1] == "",\
+            "For commit '{}', title is divided into multiple lines. " \
+            "Please keep it one line long and make sure you add a blank " \
+            "line between title and description.".format(sha)
         assert len(title) <= COMMIT_TITLE_MAX_LEN,\
             "For commit '{}', title exceeds {} chars. " \
             "Please keep it shorter.".format(sha, COMMIT_TITLE_MAX_LEN)


### PR DESCRIPTION
Without the --workspace flag, unit tests are not run in workspace crates: https://buildkite.com/rust-vmm/vmm-reference-ci/builds/53#d2f7d639-0c8e-497d-b8c4-91203be60cad.
Fixes #38 
More details in the commit messages.