### PR TITLE
buildkite: Fix audit label indentation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -204,15 +204,15 @@ steps:
           always-pull: true
           propagate-environment: true
 
-- label: "cargo-audit"
-     commands:
-       - cargo audit -q
-     retry:
-       automatic: false
-     agents:
-       os: linux
-     plugins:
-       - docker#v3.0.1:
-           image: "rustvmm/dev:v6"
-           always-pull: true
-           propagate-environment: true
+  - label: "cargo-audit"
+    commands:
+      - cargo audit -q
+    retry:
+      automatic: false
+    agents:
+      os: linux
+    plugins:
+      - docker#v3.0.1:
+          image: "rustvmm/dev:v6"
+          always-pull: true
+          propagate-environment: true


### PR DESCRIPTION
Commit b3acb307f add the cargo-audit label but indentation is wrong,
making it an invalid YAML, at least from buildkite's point of view.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>