### PR TITLE
buildkite: Skip lines should be shorter than 70 chars

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -207,7 +207,7 @@ steps:
   - label: "cargo-audit"
     commands:
       - cargo audit -q
-    skip: "Skipping until we move cargo audit to v0.12.0. See https://github.com/RustSec/advisory-db/issues/414#issuecomment-702479926"
+    skip: "Skipping until we move cargo audit to v0.12.0"
     retry:
       automatic: false
     agents:


### PR DESCRIPTION
Welcome back to the 80s.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>