### PR TITLE
don't run commit test for repos specified with git

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -194,6 +194,7 @@ steps:
   - label: "commit-format"
     commands:
       - pytest rust-vmm-ci/integration_tests/test_commit_format.py
+    if: build.env("BUILDKITE_REPO") !~ /^git@/
     retry:
       automatic: false
     agents:


### PR DESCRIPTION
Commit format test hangs if the repository is specified with git, we should skip the test for these repos until we find a safe way to run the test for these too (see #41 for more details about why is not safe).
Test is still running for repos with `https`: https://buildkite.com/rust-vmm/vm-superio-ci/builds/33