### PR TITLE
Typo fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ docker run --device=/dev/kvm \
            -it \
            --security-opt seccomp=unconfined \
            --volume $(pwd)/${crate}:/${crate} \
-           rustvmm/dev:v{$container_version}
+           rustvmm/dev:v${container_version}
 cd ${crate}
 pytest --profile=devel rust-vmm-ci/integration_tests/test_coverage.py
 ```


### PR DESCRIPTION
Just a small typo fix, it was using `rustvmm/dev:v{5}` as version.

```
$ set -x && docker run --device=/dev/kvm
            -it
            --security-opt seccomp=unconfined
            --volume $(pwd)/${crate}:/${crate}
            rustvmm/dev:v{$container_version}
++ pwd
+ docker run --device=/dev/kvm -it --security-opt seccomp=unconfined --volume /home/federico/dev/kvm-ioctls:/kvm-ioctls 'rustvmm/dev:v{5}'
docker: invalid reference format.
See 'docker run --help'.
```