### PR TITLE
exclude dependabot from the 50/72 commit rule

### DIFF
--- a/integration_tests/test_commit_format.py
+++ b/integration_tests/test_commit_format.py
@@ -31,6 +31,11 @@ def test_commit_format():
     shas = get_cmd_output(shas_cmd)
 
     for sha in shas.split():
+        # Do not enforce the commit rules when the committer is dependabot.
+        author_cmd = "git show -s --format='%ae'"
+        author = get_cmd_output(author_cmd)
+        if "dependabot" in author:
+            continue
         message_cmd = "git show --pretty=format:%B -s " + sha
         message = get_cmd_output(message_cmd)
         message_lines = message.split("\n")


### PR DESCRIPTION
When dependabot updates the rust-vmm-ci submodule, the git commit
sumamry is over 50 chars. To be able to merge PR, exclude the dependabot
user from this checks.

Fixes: https://github.com/rust-vmm/rust-vmm-ci/issues/61

Signed-off-by: Andreea Florescu <fandree@amazon.com>