### PR TITLE
check commit authors for each commit

### DIFF
--- a/integration_tests/test_commit_format.py
+++ b/integration_tests/test_commit_format.py
@@ -32,7 +32,7 @@ def test_commit_format():
 
     for sha in shas.split():
         # Do not enforce the commit rules when the committer is dependabot.
-        author_cmd = "git show -s --format='%ae'"
+        author_cmd = "git show -s --format='%ae' " + sha
         author = get_cmd_output(author_cmd)
         if "dependabot" in author:
             continue


### PR DESCRIPTION
Although we check commit authors in test_commit_format.py to skip tests
for dependabot's commits, the current code only checks the author of the
head commit.
This PR make it check each commit's author so that we can test branches
where both a dependabot's commit and other commits exist.

Signed-off-by: Keiichi Watanabe <keiichiw@chromium.org>