### PR TITLE
use the latest docker plugin version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           image: "rustvmm/dev:v12"
           always-pull: true
 
@@ -23,7 +23,7 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           image: "rustvmm/dev:v12"
           always-pull: true
 
@@ -36,7 +36,7 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           image: "rustvmm/dev:v12"
           always-pull: true
 
@@ -49,7 +49,7 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           image: "rustvmm/dev:v12"
           always-pull: true
 
@@ -61,7 +61,7 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           image: "rustvmm/dev:v12"
           always-pull: true
 
@@ -74,7 +74,7 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
           image: "rustvmm/dev:v12"
           always-pull: true
@@ -90,7 +90,7 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
           image: "rustvmm/dev:v12"
           always-pull: true
@@ -106,7 +106,7 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
           image: "rustvmm/dev:v12"
           always-pull: true
@@ -122,7 +122,7 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
           image: "rustvmm/dev:v12"
           always-pull: true
@@ -138,7 +138,7 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           image: "rustvmm/dev:v12"
           always-pull: true
 
@@ -151,7 +151,7 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
           image: "rustvmm/dev:v12"
           always-pull: true
@@ -165,7 +165,7 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
           image: "rustvmm/dev:v12"
           always-pull: true
@@ -179,7 +179,7 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
           image: "rustvmm/dev:v12"
           always-pull: true
@@ -196,7 +196,7 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
           image: "rustvmm/dev:v12"
           always-pull: true
@@ -212,7 +212,7 @@ steps:
     agents:
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           image: "rustvmm/dev:v12"
           always-pull: true
           propagate-environment: true
@@ -225,7 +225,7 @@ steps:
     agents:
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           image: "rustvmm/dev:v12"
           always-pull: true
           propagate-environment: true


### PR DESCRIPTION
This version is needed because there are features (for example passing
devices to a container) that are not available in the old version.