### PR TITLE
Update test_commit_format.py to work locally

### DIFF
--- a/integration_tests/test_commit_format.py
+++ b/integration_tests/test_commit_format.py
@@ -1,6 +1,14 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Test the commit message format."""
+"""
+Test the commit message format.
+
+This test works properly on the local machine only when the environment
+variables BASE_BRANCH and REMOTE are set. Otherwise the default values
+are "master" for the name of the base branch and "origin" for the
+remote name of the upstream repository, and this test may not work as
+expected.
+"""
 
 import os
 import subprocess
@@ -9,8 +17,14 @@ from utils import get_cmd_output
 
 COMMIT_TITLE_MAX_LEN = 50
 COMMIT_BODY_LINE_MAX_LEN = 72
-BASE_BRANCH = os.environ['BUILDKITE_PULL_REQUEST_BASE_BRANCH']
-BASE_REPO = os.environ['BUILDKITE_REPO']
+BASE_BRANCH = \
+    os.environ.get('BUILDKITE_PULL_REQUEST_BASE_BRANCH') or \
+    os.environ.get('BASE_BRANCH') or \
+    "master"
+REMOTE = \
+    os.environ.get('BUILDKITE_REPO') or \
+    os.environ.get('REMOTE') or \
+    "origin"
 
 
 def test_commit_format():
@@ -22,8 +36,14 @@ def test_commit_format():
     and if commits are signed.
     """
     # Fetch the upstream repository.
-    fetch_base_cmd = "git fetch {} {}".format(BASE_REPO, BASE_BRANCH)
-    subprocess.run(fetch_base_cmd, shell=True, check=True)
+    fetch_base_cmd = "git fetch {} {}".format(REMOTE, BASE_BRANCH)
+    try:
+        subprocess.run(fetch_base_cmd, shell=True, check=True)
+    except subprocess.CalledProcessError:
+        raise NameError(
+            "The name of the base branch or remote is invalid. "
+            "See test documentation for more details."
+        ) from None
     # Get hashes of PR's commits in their abbreviated form for
     # a prettier printing.
     shas_cmd = "git log --no-merges --pretty=%h --no-decorate " \


### PR DESCRIPTION
Set default values for the base repository and base branch when the test is run locally and the Buildkite variables are not available.