### PR TITLE
Setup for rust-vmm-ci-ci

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -172,7 +172,7 @@ steps:
 
   - label: "coverage-x86"
     commands:
-      - pytest rust-vmm-ci/integration_tests/test_coverage.py
+      - find . -type f -name "test_coverage.py" | xargs pytest
     retry:
       automatic: false
     agents:
@@ -205,7 +205,7 @@ steps:
 
   - label: "commit-format"
     commands:
-      - pytest rust-vmm-ci/integration_tests/test_commit_format.py
+      - find . -type f -name "test_commit_format.py" | xargs pytest
     if: build.env("BUILDKITE_REPO") !~ /^git@/
     retry:
       automatic: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "rust-vmm-ci"
+version = "0.1.0"
+
+[dependencies]

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,0 +1,5 @@
+{
+    "coverage_score": 33.3, 
+    "exclude_path": "", 
+    "crate_features": ""
+}

--- a/integration_tests/test_coverage.py
+++ b/integration_tests/test_coverage.py
@@ -7,11 +7,29 @@ import pytest
 
 from utils import get_repo_root_path
 
+
+def get_coverage_config_path():
+    machine = platform.machine()
+    target_file = f"coverage_config_{machine}.json"
+    # We use a breadth-first search to guarantee that the config file
+    # belongs to the crate that is being tested. Otherwise we might end
+    # up wrongfully using the config file in the rust-vmm-ci submodule.
+    # os.walkdir() offers a depth-first search and couldn't be used here.
+    dirs = [os.getcwd()]
+    while len(dirs):
+        nextDirs = []
+        for dir in dirs:
+            for file in os.listdir(dir):
+                file_path = os.path.join(dir, file)
+                if os.path.isdir(file_path):
+                    nextDirs.append(file_path)
+                elif file == target_file:
+                    return file_path
+        dirs = nextDirs
+
+
 REPO_ROOT_PATH = get_repo_root_path()
-if platform.machine() == "x86_64":
-    COVERAGE_CONFIG_PATH = os.path.join(REPO_ROOT_PATH, "coverage_config_x86_64.json")
-elif platform.machine() == "aarch64":
-    COVERAGE_CONFIG_PATH = os.path.join(REPO_ROOT_PATH, "coverage_config_aarch64.json")
+COVERAGE_CONFIG_PATH = get_coverage_config_path()
 
 
 def _read_test_config():

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn main() {
+    println!("It works!");
+}


### PR DESCRIPTION
In order to be able to run the CI on rust-vmm-ci we needed to
make it a rust crate. Also the path to the coverage config
file needed to be updated in test_coverage.py so that the path
does not depend on the crate; a breadth-first search was used
to guarantee that the config file belongs to the crate that is
being tested.

In the other crates, the tests reside in rust-vmm-ci/intergation_tests.
When we test the CI itself, the tests reside in integration_tests.
Therefore we needed to update the pytest commands to find the tests 
independently of the crate they are run from.
