### PR TITLE
make the test description configurable

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -45,6 +45,8 @@ import sys
 import pathlib
 import copy
 
+from optparse import OptionParser
+
 # This represents the version of the rust-vmm-container used
 # for running the tests.
 CONTAINER_VERSION = "v12"
@@ -239,7 +241,7 @@ class BuildkiteConfig:
         return vars(self)
 
 
-def generate_pipeline(config_file=f"{PARENT_DIR}/test_description.json"):
+def generate_pipeline(config_file):
     """ Generate the pipeline yaml file from a json configuration file. """
 
     with open(config_file) as json_file:
@@ -252,4 +254,14 @@ def generate_pipeline(config_file=f"{PARENT_DIR}/test_description.json"):
 
 
 if __name__ == '__main__':
-    generate_pipeline()
+    parser = OptionParser()
+    # By default we're generating the rust-vmm-ci pipeline with the test
+    # configuration committed to this repository.
+    # This parameter is useful for generating the pipeline for repositories
+    # that have custom pipelines, and it helps with keeping the container
+    # version the same across pipelines.
+    parser.add_option("-t", "--test-description", dest="test_description",
+                      help="JSON file containing the test description.",
+                      default=f"{PARENT_DIR}/test_description.json")
+    (options, args) = parser.parse_args()
+    generate_pipeline(options.test_description)


### PR DESCRIPTION
Make it possible for autogenerating pipelines that are not committed to
this repository, but that are passed as a parameter. The need for this
behavior comes from a problem we've been facing with repositories that
also have custom pipelines. It happens that the container version (which
impacts the rust version), and the docker plugin version are lagging
behind, and are making tests ocasionally fail. To make sure that both
custom pipelines and the rust-vmm-ci pipeline are using the same Rust &
other environment versions, we're using the same script for generating
those tests as well.

This cannot be applied to Windows pipelines as they're not using the
rust-vmm-container at the moment.