### PR TITLE
Update clippy test command

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -38,7 +38,7 @@
     },
     {
       "test_name": "clippy",
-      "command": "cargo clippy --workspace --bins --examples --benches --all-features -- -D warnings",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-features --all-targets -- -D warnings",
       "platform": [
         "x86_64",
         "aarch64"


### PR DESCRIPTION
Added the option `--all-targets` to the command in the clippy test for clippy to also run on the integration tests.