### PR TITLE
Check formatting of code examples in doc comments

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -18,7 +18,7 @@
     },
     {
       "test_name": "style",
-      "command": "cargo fmt --all -- --check"
+      "command": "cargo fmt --all -- --check --config format_code_in_doc_comments=true"
     },
     {
       "test_name": "unittests-gnu",


### PR DESCRIPTION
Add format_code_in_doc_comments=true to the cargo fmt
config options.

Fixes: https://github.com/rust-vmm/rust-vmm-ci/issues/58

Signed-off-by: Sergii Glushchenko <gsserge@amazon.com>