### PR TITLE
Assert no spaces in crate features JSON

### DIFF
--- a/integration_tests/test_coverage.py
+++ b/integration_tests/test_coverage.py
@@ -51,6 +51,9 @@ def _read_test_config():
     assert "exclude_path" in coverage_config
     assert "crate_features" in coverage_config
 
+    assert ' ' not in coverage_config["crate_features"], \
+        "spaces are not allowed in crate_features value"
+
     return coverage_config
 
 


### PR DESCRIPTION
Spaces in the `crate_features` JSON value can cause errors when running `kcov`.
 
The `json.load()` method used to load the JSON file will raise an error if it's not valid JSON as mentioned on the python [json module docs](https://docs.python.org/3/library/json.html)
> If the data being deserialized is not a valid JSON document, a JSONDecodeError will be raised.

Fixes: #74 
