### PR TITLE
update test_coverage to allow running it on crates

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,10 +1,13 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
 
 PROFILE_CI = "ci"
 PROFILE_DEVEL = "devel"
+
+WORKSPACE = "workspace"
+CRATE = "crate"
 
 
 def pytest_addoption(parser):
@@ -26,6 +29,16 @@ def pytest_addoption(parser):
              "removed."
     )
 
+    parser.addoption(
+        "--test-scope",
+        default=WORKSPACE,
+        choices=[WORKSPACE, CRATE],
+        help="Defines the scope of running tests: {} or {}".format(
+            WORKSPACE,
+            CRATE
+        )
+    )
+
 
 @pytest.fixture
 def profile(request):
@@ -37,7 +50,16 @@ def no_cleanup(request):
     return request.config.getoption("--no-cleanup")
 
 
+@pytest.fixture
+def test_scope(request):
+    return request.config.getoption("--test-scope")
+
+
 # This is used for defining global variables in pytest.
 def pytest_configure():
+    # These constants are needed in tests, so this is the way that we can
+    # export them.
     pytest.profile_ci = PROFILE_CI
     pytest.profile_devel = PROFILE_DEVEL
+    pytest.workspace = WORKSPACE
+    pytest.crate = CRATE


### PR DESCRIPTION
The test was assuming that we always want to run all the tests in an
workspace, but that is not the case when we have multiple crates that we
want to publish part of the same workspace.

To address this issue, we can now select to run the coverage test only
on the crate in scope. This can be achieved by passing the parameter
`--test-scope` with the value "crate". By default, tests are still
running as a workspace so that we do not need to update all the other
rust-vmm components that were counting on this feature.

The `test-scope` option can also be reused in other tests that are
making use of `--all`. For example, cargo build.