### PR TITLE
run `cargo audit` with `--deny warnings` enabled

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -71,7 +71,7 @@
     },
     {
       "test_name": "cargo-audit",
-      "command": "cargo audit -q"
+      "command": "cargo audit -q --deny warnings"
     }
   ]
 }


### PR DESCRIPTION
Make the CI fail on cargo audit warnings as well. Example: https://rustsec.org/advisories/RUSTSEC-2021-0127.html.