### PR TITLE
Allow new keys in pipeline generation

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -233,6 +233,17 @@ class BuildkiteStep:
         self._env_add_docker_config(test_name)
         self._env_override_timeout(test_name)
 
+        # We're now adding the keys for which we don't have explicit support
+        # (i.e. there is no checking/updating taking place). We are just
+        # forwarding the key, values without any change.
+        # We need to filter for keys that have special meaning and which we
+        # don't want to re-add.
+        special_keys = ['conditional', 'docker_plugin', 'platform', 'test_name']
+        additional_keys = {k: v for k, v in input.items() if not (k in self.step_config) and
+                           not(k in special_keys)}
+        if additional_keys:
+            self.step_config.update(additional_keys)
+
         # Return the object's attributes and their values as a dictionary.
         return self.step_config
 

--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -127,6 +127,11 @@ class BuildkiteStep:
         if timeout:
             self.step_config['timeout_in_minutes'] = timeout
 
+    def _set_agent_queue(self, queue):
+        """Set the agent queue if provided in the json input."""
+        if queue:
+            self.step_config['agents']['queue'] = queue
+
     def _add_docker_config(self, cfg):
         """ Add configuration for docker if given in the json input. """
 
@@ -207,6 +212,7 @@ class BuildkiteStep:
         docker = input.get('docker_plugin')
         conditional = input.get('conditional')
         timeout = input.get('timeout_in_minutes')
+        queue = input.get('queue')
 
         # Mandatory keys.
         assert test_name, "Step is missing test name."
@@ -227,6 +233,7 @@ class BuildkiteStep:
         self._set_conditional(conditional)
         self._add_docker_config(docker)
         self._set_timeout_in_minutes(timeout)
+        self._set_agent_queue(queue)
 
         # Override/add configuration from environment variables.
         self._env_override_agent_tags(test_name)
@@ -238,7 +245,7 @@ class BuildkiteStep:
         # forwarding the key, values without any change.
         # We need to filter for keys that have special meaning and which we
         # don't want to re-add.
-        special_keys = ['conditional', 'docker_plugin', 'platform', 'test_name']
+        special_keys = ['conditional', 'docker_plugin', 'platform', 'test_name', 'queue']
         additional_keys = {k: v for k, v in input.items() if not (k in self.step_config) and
                            not(k in special_keys)}
         if additional_keys:


### PR DESCRIPTION
### Summary of the PR

This PR is doing a refactoring that enables us to forward the keys that we do not recognize in the JSON test description to the auto-generated pipeline. This is needed so that we have more flexibility in using new features from Buildkite. Before this change unrecognized pipeline configurations were just dropped.

More details are available in the commit messages.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
