### PR TITLE
don't allow undocumented unsafe blocks

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -38,7 +38,7 @@
     },
     {
       "test_name": "clippy",
-      "command": "cargo clippy --workspace --bins --examples --benches --all-features --all-targets -- -D warnings",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-features --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks",
       "platform": [
         "x86_64",
         "aarch64"


### PR DESCRIPTION
We already have this as a requirement for merging PRs as part of the PR checklist template, but it's better to enforce it. This comes with the disadvantage that we will need to update all comments and add the prefix "SAFETY: " as required by the clippy check.

Signed-off-by: Andreea Florescu <fandree@amazon.com>

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
