### PR TITLE
.buildkite: add hypervisor to special_keys

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -254,7 +254,7 @@ class BuildkiteStep:
         # forwarding the key, values without any change.
         # We need to filter for keys that have special meaning and which we
         # don't want to re-add.
-        special_keys = ['conditional', 'docker_plugin', 'platform', 'test_name', 'queue']
+        special_keys = ['conditional', 'docker_plugin', 'platform', 'test_name', 'queue', 'hypervisor']
         additional_keys = {k: v for k, v in input.items() if not (k in self.step_config) and
                            not(k in special_keys)}
         if additional_keys:


### PR DESCRIPTION
Without this fix, yml is generated wrongly like below:

steps:
- label: coverage-x86_64 
- command: pytest $(find . -type f -name "test_coverage.py") 
- retry: automatic: false 
- agents: 
   -  os: linux platform: x86_64.metal
   -  hypervisor: mshv plugins:
- docker#v3.8.0: image: rustvmm/dev:v16 
- always-pull: true privileged: true 
- timeout_in_minu**tes: 5 
- hypervisor: mshv // This is now right**

Signed-off-by: Muminul Islam <muislam@microsoft.com>

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
