### PR TITLE
update to container v21

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -60,7 +60,7 @@ from textwrap import dedent
 
 # This represents the version of the rust-vmm-container used
 # for running the tests.
-CONTAINER_VERSION = "v19"
+CONTAINER_VERSION = "v21"
 # This represents the version of the Buildkite Docker plugin.
 DOCKER_PLUGIN_VERSION = "v5.3.0"
 

--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -71,7 +71,10 @@
     },
     {
       "test_name": "cargo-audit",
-      "command": "cargo audit -q --deny warnings"
+      "command": "cargo audit -q --deny warnings",
+      "platform": [
+        "x86_64"
+      ]
     }
   ]
 }


### PR DESCRIPTION
That updates to a newer version of Rust, 1.68.2, and adds back libclang-dev package which is required by vhost-device/gpio crates.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
