### PR TITLE
Fix coverage paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,10 @@ cd ${crate}
 pytest --profile=devel rust-vmm-ci/integration_tests/test_coverage.py
 ```
 
-If the PR coverage is higher than the upstream coverage, the coverage file
-needs to be manually added to the commit before submitting the PR:
+Sample coverage_config files:
+
+- [x86](coverage_config_x86_64.json.sample)
+- [aarch64](coverage_config_aarch64.json.sample)
 
 If the PR coverage is higher than the upstream coverage, the coverage file
 needs to be manually added to the commit before submitting the PR. For example:

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ To update the coverage before submitting a PR, run the coverage test:
 CRATE="kvm-ioctls"
 # NOTE: This might not be the latest container version, you can check which one we're using
 # by looking into the .buildkite/autogenerate_pipeline.py file.
-LATEST=16
+LATEST=21
 docker run --device=/dev/kvm \
            -it \
            --security-opt seccomp=unconfined \

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The integration tests support two test profiles:
 The test profiles are applicable to
 [`pytest`](https://docs.pytest.org/en/latest/), the integration test framework
 used with rust-vmm-ci. Currently only the
-[coverage test](tests/test_coverage.py) follows this model as all the other
+[coverage test](integration_tests/test_coverage.py) follows this model as all the other
 integration tests are run using the Buildkite pipeline.
 
 The difference between is declaring tests as passed or failed:
@@ -208,8 +208,9 @@ Further details about the coverage test can be found in the
 
 ### Adaptive Coverage
 
-The line coverage is saved in [tests/coverage](tests/coverage). To update the
-coverage before submitting a PR, run the coverage test:
+The line coverage is saved in either [coverage_config_x86_64.json](coverage_config_x86_64.json) or
+coverage_config_aarch64.json, depending on your machine's architecture. 
+To update the coverage before submitting a PR, run the coverage test:
 
 ```bash
 CRATE="kvm-ioctls"
@@ -228,8 +229,10 @@ pytest --profile=devel rust-vmm-ci/integration_tests/test_coverage.py
 If the PR coverage is higher than the upstream coverage, the coverage file
 needs to be manually added to the commit before submitting the PR:
 
+If the PR coverage is higher than the upstream coverage, the coverage file
+needs to be manually added to the commit before submitting the PR. For example:
 ```bash
-git add tests/coverage
+git add coverage_config_x86_64.json
 ```
 
 Failing to do so will generate a fail on the CI pipeline when publishing the
@@ -237,7 +240,8 @@ PR.
 
 **NOTE:** The coverage file is only updated in the `devel` test profile. In
 the `ci` profile the coverage test will fail if the current coverage is higher
-than the coverage reported in [tests/coverage](tests/coverage).
+than the coverage reported in [coverage_config_x86_64.json](coverage_config_x86_64.json)
+_(or coverage_config_aarch64.json)_.
 
 ### Performance tests
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ steps:
     platform: arm.metal
   plugins:
   - docker#v3.8.0:
-      image: rustvmm/dev:v16
+      image: rustvmm/dev:v21
       always-pull: true
 ```
 
@@ -328,7 +328,7 @@ cd ~/vm-superio
 CRATE="vm-superio"
 # NOTE: This might not be the latest container version, you can check which one we're using
 # by looking into the .buildkite/autogenerate_pipeline.py file.
-LATEST=16
+LATEST=21
 docker run -it \
            --security-opt seccomp=unconfined \
            --volume $(pwd):/${CRATE} \


### PR DESCRIPTION
Addresses issue #5.

Fixes out-of-date paths to coverage-related files in the README and adds references to sample coverage_config files.

Also updates the container version to match the latest as given in .buildkite/autogenerate_pipeline.py