### PR TITLE
Use derivatives of BaseException for exceptions

### DIFF
--- a/integration_tests/test_coverage.py
+++ b/integration_tests/test_coverage.py
@@ -147,7 +147,7 @@ def test_coverage(profile, no_cleanup, test_scope):
         if previous_coverage < current_coverage:
             if profile == pytest.profile_ci:
                 # In the CI Profile we expect the coverage to be manually updated.
-                raise msg
+                raise ValueError(msg)
             elif profile == pytest.profile_devel:
                 coverage_config["coverage_score"] = current_coverage
                 _write_coverage_config(coverage_config)
@@ -155,6 +155,6 @@ def test_coverage(profile, no_cleanup, test_scope):
                 # This should never happen because pytest should only accept
                 # the valid test profiles specified with `choices` in
                 # `pytest_addoption`.
-                raise "Invalid test profile."
+                raise RuntimeError("Invalid test profile.")
         elif previous_coverage > current_coverage:
-            raise msg
+            raise ValueError(msg)


### PR DESCRIPTION
### Summary of the PR

When the coverage changes, we raise exceptions with simple strings, this causes the following error:

    TypeError: exceptions must derive from BaseException

Let's use derivatives of BaseException to fix this issue.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
