### PR TITLE
Have coverage test use llvm-cov instead of cargo-kcov

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -60,7 +60,7 @@ from textwrap import dedent
 
 # This represents the version of the rust-vmm-container used
 # for running the tests.
-CONTAINER_VERSION = "v24"
+CONTAINER_VERSION = "v26"
 # This represents the version of the Buildkite Docker plugin.
 DOCKER_PLUGIN_VERSION = "v5.3.0"
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-    "coverage_score": 33.3, 
+    "coverage_score": 100.0, 
     "exclude_path": "", 
     "crate_features": ""
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
-pub fn main() {
-    println!("It works!");
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_add() {
+        assert_eq!(super::add(1, 2), 3)
+    }
 }


### PR DESCRIPTION
cargo-kcov is broken on rust versions >=1.71.0. This is currently blocking us from upgrading to the new toolchain version (1.72.0), which is required to compile linux-loader (due to one dependency having a MSRV policy of "N-2", meaning our current toolchain is no longer supported).

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
