### PR TITLE
README: Fix link to setup_new_repo.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ to the repository as well.
 
 3. Create a new pipeline definition in Buildkite. For this step ask one of the
 rust-vmm Buildkite [admins](CODEOWNERS) to create one for you. The process is explained
-[here](https://github.com/rust-vmm/community/blob/main/docs/maintainers/setup_new_repo.md#set-up-ci).
+[here](https://github.com/rust-vmm/community/blob/main/docs/setup_new_repo.md#set-up-ci).
 
 4. There is a script that autogenerates a dynamic Buildkite pipeline. Each step
 in the pipeline has a default timeout of 5 minutes. To run the CI using this dynamic pipeline,


### PR DESCRIPTION
The community repo has moved documents from the `maintainers` folder: https://github.com/rust-vmm/community/commit/9c611c5727341e2e96c7ca0c4ba00d6ff9ee8bf7

### Summary of the PR

Fix outdated link.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [N/A] All added/changed functionality has a corresponding unit/integration
  test.
- [N/A] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [N/A] Any newly added `unsafe` code is properly documented.
