### PR TITLE
test_coverage: fix formatting of --ignore-filename-regex

### DIFF
--- a/integration_tests/test_coverage.py
+++ b/integration_tests/test_coverage.py
@@ -82,7 +82,7 @@ def _get_current_coverage(coverage_config, no_cleanup, test_scope):
 
     additional_exclude_path = coverage_config["exclude_path"]
     if additional_exclude_path:
-        llvm_cov_command += f" --ignore-filename-regex \"{additional_exclude_path}\""
+        llvm_cov_command += f' --ignore-filename-regex "{additional_exclude_path}"'
 
     if test_scope == pytest.workspace:
         llvm_cov_command += " --workspace "


### PR DESCRIPTION
### Summary of the PR

`black` suggests putting the string between single quotes so there is no need to escape double quotes.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
