### PR TITLE
test_coverage: calculate the difference in reverse

### DIFF
--- a/integration_tests/test_coverage.py
+++ b/integration_tests/test_coverage.py
@@ -116,7 +116,7 @@ def test_coverage(profile, no_cleanup, test_scope):
     coverage_config = _read_test_config()
     current_coverage = _get_current_coverage(coverage_config, no_cleanup, test_scope)
     previous_coverage = coverage_config["coverage_score"]
-    diff = previous_coverage - current_coverage
+    diff = current_coverage - previous_coverage
     upper = previous_coverage + MAX_DELTA
     arch = platform.machine()
 


### PR DESCRIPTION
### Summary of the PR

If we increase the coverage the message prints a negative value as the difference from the previous value. This can be confusing as it looks like the coverage has decreased.

For example if the value in coverage_config_x86_64.json is 73.42, and the new coverage is 73.96 (increased), we have the following error:

    ValueError: Current code coverage (73.96%) deviates by -0.54%
    from the previous code co...

Let's calculate the difference in reverse so that we have a negative value if it decreases and positive otherwise.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
