### PR TITLE
Initial support for riscv64 Buildkite CI

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -36,6 +36,13 @@
       ]
     },
     {
+      "test_name": "unittests-gnu",
+      "command": "cargo test --no-run --target=riscv64gc-unknown-linux-gnu --config target.riscv64gc-unknown-linux-gnu.linker=\\\"riscv64-linux-gnu-gcc\\\" && qemu.sh",
+      "platform": [
+	"riscv64"
+      ]
+    },
+    {
       "test_name": "unittests-musl",
       "command": "cargo test --all-features --workspace --target {target_platform}-unknown-linux-musl",
       "platform": [

--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -9,6 +9,13 @@
       ]
     },
     {
+      "test_name": "build-gnu",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo build --release --target=riscv64gc-unknown-linux-gnu --config target.riscv64gc-unknown-linux-gnu.linker=\\\"riscv64-linux-gnu-gcc\\\"",
+      "platform": [
+	"riscv64"
+      ]
+    },
+    {
       "test_name": "build-musl",
       "command": "RUSTFLAGS=\"-D warnings\" cargo build --release --target {target_platform}-unknown-linux-musl",
       "platform": [


### PR DESCRIPTION
### Summary of the PR

- Enable `build-gnu-riscv64` and `unittests-gnu-riscv64`
- To be used with the container in https://github.com/rust-vmm/rust-vmm-container/pull/91
- Need help from Docker Hub admin to create a new repository `rustvmm/dev_riscv64` (see https://github.com/rust-vmm/rust-vmm-container/issues/96). The checks below fail due to not having such repository.
- Need help from Buildkite admin to update the pipeline

The riscv64-related outputs of the `autogenerate_pipeline.py`:
```
- label: build-gnu-riscv64
  command: RUSTFLAGS="-D warnings" cargo build --release --target=riscv64gc-unknown-linux-gnu
    --config target.riscv64gc-unknown-linux-gnu.linker=\"riscv64-linux-gnu-gcc\"
  retry:
    automatic: false
  agents:
    os: linux
    platform: x86_64.metal
    hypervisor: kvm
  plugins:
  - docker#v5.3.0:
      image: rustvmm/dev_riscv64:v1
      always-pull: true
  timeout_in_minutes: 15
```
and
```
- label: unittests-gnu-riscv64
  command: cargo test --no-run --target=riscv64gc-unknown-linux-gnu --config target.riscv64gc-unknown-linux-gnu.linker=\"riscv64-linux-gnu-gcc\"
    && qemu.sh
  retry:
    automatic: false
  agents:
    os: linux
    platform: x86_64.metal
    hypervisor: kvm
  plugins:
  - docker#v5.3.0:
      image: rustvmm/dev_riscv64:v1
      always-pull: true
  timeout_in_minutes: 15

```
### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [N/A] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [N/A] Any newly added `unsafe` code is properly documented.
