### PR TITLE
Add example dependabot configurations to rust-vmm-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,19 @@ The json must have the following fields:
 This file is required for the coverage integration so it needs to be added
 to the repository as well.
 
-3. Create a new pipeline definition in Buildkite. For this step ask one of the
+3. Copy one of the two provided dependabot configurations to `.github/dependabot.yml`,
+   e.g. run `cp rust-vmm-ci/dependabot-{weekly,monthly}.yml .github/dependabot.yml`.
+   Note that just symlinking the file does not work, as dependabot will not
+   follow symlinks into submodules. This means that updates to these files made in
+   rust-vmm-ci will need to be manually consumed for now. We recommend setting up
+   weekly dependabot updates only if the crate receives multiple contributions a week,
+   and if you expect to have the bandwidth to address weekly dependency PRs.
+
+4. Create a new pipeline definition in Buildkite. For this step ask one of the
 rust-vmm Buildkite [admins](CODEOWNERS) to create one for you. The process is explained
 [here](https://github.com/rust-vmm/community/blob/main/docs/setup_new_repo.md#set-up-ci).
 
-4. There is a script that autogenerates a dynamic Buildkite pipeline. Each step
+5. There is a script that autogenerates a dynamic Buildkite pipeline. Each step
 in the pipeline has a default timeout of 5 minutes. To run the CI using this dynamic pipeline,
 you need to add a step that is uploading the rust-vmm-ci pipeline:
 ```bash
@@ -108,7 +116,7 @@ For most use cases, overriding or extending the configuration is not necessary. 
 want to do so if, for example, the platform needs a custom device that is not available
 on the existing test instances or if we need a specialized hypervisor.
 
-5. The code owners of the repository will have to setup a WebHook for
+6. The code owners of the repository will have to setup a WebHook for
 triggering the CI on
 [pull request](https://developer.github.com/v3/activity/events/types/#pullrequestevent)
 and [push](https://developer.github.com/v3/activity/events/types/#pushevent)

--- a/dependabot-monthly.yml
+++ b/dependabot-monthly.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+
+# A monthly update of the rust-vmm-ci submodule
+- package-ecosystem: gitsubmodule
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 1
+
+# A monthly update to rust dependencies. These will be grouped,
+# e.g. one PR will contains updates for all dependencies.
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 1
+  # Make it also update transitive dependencies in Cargo.lock
+  allow:
+    - dependency-type: "all"
+  # Group all available updates into a group called "rust-dependencies"
+  groups:
+    rust-dependencies:
+      patterns:
+        - "*"

--- a/dependabot-weekly.yml
+++ b/dependabot-weekly.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+
+# A weekly update of the rust-vmm-ci submodule
+- package-ecosystem: gitsubmodule
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+  open-pull-requests-limit: 1
+
+# A weekly update to rust dependencies. These will be grouped,
+# e.g. one PR will contains updates for all dependencies.
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+  open-pull-requests-limit: 1
+  # Make it also update transitive dependencies in Cargo.lock
+  allow:
+    - dependency-type: "all"
+  # Group all available updates into a group called "rust-dependencies"
+  groups:
+    rust-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
### Summary of the PR

Adds example dependabot configurations that individual rust-vmm crates could utilize (see https://github.com/rust-vmm/community/issues/177 for a discussion)

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
