### PR TITLE
Add riscv64 gnu build and unit-test CI

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -9,6 +9,13 @@
       ]
     },
     {
+      "test_name": "build-riscv-gnu",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo build --release --target=riscv64gc-unknown-linux-gnu --config target.riscv64gc-unknown-linux-gnu.linker=\\\"riscv64-linux-gnu-gcc\\\" --config target.riscv64gc-unknown-linux-gnu.runner=\\\"/usr/bin/qemu-riscv64-static\\\"",
+      "platform": [
+        "x86_64"
+      ]
+    },
+    {
       "test_name": "build-musl",
       "command": "RUSTFLAGS=\"-D warnings\" cargo build --release --target {target_platform}-unknown-linux-musl",
       "platform": [
@@ -26,6 +33,13 @@
       "platform": [
         "x86_64",
         "aarch64"
+      ]
+    },
+    {
+      "test_name": "unittests-riscv-gnu",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo test --all-features --target=riscv64gc-unknown-linux-gnu --config target.riscv64gc-unknown-linux-gnu.linker=\\\"riscv64-linux-gnu-gcc\\\" --config target.riscv64gc-unknown-linux-gnu.runner=\\\"/usr/bin/qemu-riscv64-static\\\"",
+      "platform": [
+        "x86_64"
       ]
     },
     {


### PR DESCRIPTION
Add two tests based on `qemu-riscv64-static` CPU emulator on x86_64 platform.

### Summary of the PR

Since there is no RISC-V machines available on BuildKite, I propose using x86_64 architecture to do cross-compilation test, and `qemu-riscv64-static` CPU emulator to do `cargo test`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
