### PR TITLE
update container version to v35

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -60,7 +60,7 @@ from textwrap import dedent
 
 # This represents the version of the rust-vmm-container used
 # for running the tests.
-CONTAINER_VERSION = "v34"
+CONTAINER_VERSION = "v35"
 # This represents the version of the Buildkite Docker plugin.
 DOCKER_PLUGIN_VERSION = "v5.3.0"
 


### PR DESCRIPTION
### Summary of the PR

This version includes libepoxy dependencies
which is required for vhost-device-gpu crate
more info about the crate can be found here:
https://github.com/rust-vmm/vhost-device/pull/668
link to the container PR that adds libepoxy
where the tag is generated can be found here:
https://github.com/rust-vmm/rust-vmm-container/pull/103

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
