### PR TITLE
run unittests in privileged docker container

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -28,7 +28,10 @@
         "x86_64",
         "aarch64",
         "riscv64"
-      ]
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
     },
     {
       "test_name": "unittests-musl",
@@ -36,7 +39,10 @@
       "platform": [
         "x86_64",
         "aarch64"
-      ]
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
     },
     {
       "test_name": "clippy",


### PR DESCRIPTION
The code coverage tests already run in a privileged container, so this does not affect our security posture. Additionally, it will unblock vsock unit tests in the vhost-user-vsock crate, see also https://github.com/rust-vmm/vhost-device/pull/706 and https://github.com/rust-vmm/vhost-device/pull/728

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
