### PR TITLE
ci: Enalbe tests with no `platform` specified

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -328,7 +328,7 @@ class BuildkiteConfig:
 
             for platform in platforms:
                 # Filter test enabled in platform_allowlist
-                if platform not in platform_allowlist:
+                if platform is not None and platform not in platform_allowlist:
                     # Skip disabled platform
                     continue
 


### PR DESCRIPTION
### Summary of the PR

After `.platform` mechanism was introduced in https://github.com/rust-vmm/rust-vmm-ci/pull/159, it silently filters
out tests with no `platform` specified. Enable them to execute by adding
`platform is not None` predicate preceeds allowlist check.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
