### PR TITLE
update container version to v47

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -60,7 +60,7 @@ from textwrap import dedent
 
 # This represents the version of the rust-vmm-container used
 # for running the tests.
-CONTAINER_VERSION = "v46"
+CONTAINER_VERSION = "v47"
 # The suffix suggests that the dev image with `v{N}-riscv` tag is not to be
 # confused with real `riscv64` image (it's actually a `x86_64` image with
 # `qemu-system-riscv64` installed), since AWS yet has `riscv64` machines


### PR DESCRIPTION
### Summary of the PR

Version v47 [1] incorporates:
- chore: Move RUST_TOOLCHAIN into build_container.sh
- chore: Refactor dialing to reduce useless hints
- riscv64: Set MIN_CORES to 4

[1] rust-vmm/rust-vmm-container#118

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
