### PR TITLE
fix: have benchmark test clean working directory

### DIFF
--- a/integration_tests/test_benchmark.py
+++ b/integration_tests/test_benchmark.py
@@ -101,14 +101,21 @@ def _run_critcmp():
     print(p.stderr.decode("utf-8"))
 
 
+def _clean_workdir():
+    subprocess.run("git restore .", shell=True, check=True)
+    subprocess.run("git clean -fd", shell=True, check=True)
+
+
 def _git_checkout_upstream_branch():
     subprocess.run(
         "git fetch {} {}".format(REMOTE, BASE_BRANCH), shell=True, check=True
     )
+    _clean_workdir()
     subprocess.run("git checkout FETCH_HEAD", shell=True, check=True)
 
 
 def _git_checkout_pr_branch():
+    _clean_workdir()
     subprocess.run(
         "git checkout -",
         shell=True,


### PR DESCRIPTION
Before checking out different commits, clean the working directory to avoid checkout failures to to temporary files created during benchmark execution (as is done by linux-loader)

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
