### PR TITLE
feat: run unit tests with --release flag

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -45,6 +45,29 @@
       }
     },
     {
+      "test_name": "unittests-gnu-release",
+      "command": "cargo test --release --all-features --workspace",
+      "platform": [
+        "x86_64",
+        "aarch64",
+        "riscv64"
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
+    },
+    {
+      "test_name": "unittests-musl-release",
+      "command": "cargo test --release --all-features --workspace --target {target_platform}-unknown-linux-musl",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
+    },
+    {
       "test_name": "clippy",
       "command": "cargo clippy --workspace --bins --examples --benches --all-features --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks",
       "platform": [


### PR DESCRIPTION
### Summary of the PR

Rust does optimizations which can cause havoc in `--release` mode, so add another set of unit tests
with all optimizations enabled.

See: https://github.com/rust-vmm/kvm/pull/298

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
