### PR TITLE
chore: Update container version to `g538dba3`

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -60,7 +60,7 @@ from textwrap import dedent
 
 # This represents the version of the rust-vmm-container used
 # for running the tests.
-CONTAINER_VERSION = "v48"
+CONTAINER_VERSION = "g538dba3"
 # The suffix suggests that the dev image with `v{N}-riscv` tag is not to be
 # confused with real `riscv64` image (it's actually a `x86_64` image with
 # `qemu-system-riscv64` installed), since AWS yet has `riscv64` machines


### PR DESCRIPTION
### Summary of the PR

We have switched to git sha1 tagging since v49. For details, see:
https://github.com/rust-vmm/rust-vmm-container/pull/121.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
