### PR TITLE
dependabot: drop open-pull-requests-limit

### DIFF
--- a/dependabot-monthly.yml
+++ b/dependabot-monthly.yml
@@ -1,12 +1,15 @@
 version: 2
 updates:
 
+# We do not set open-pull-requests-limit, as sometimes
+# dependabot thinks the limit is hit without actually having
+# any PRs open. In reality, the configs below can only result
+# in at most one PR per package ecosyste manyway.
 # A monthly update of the rust-vmm-ci submodule
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
     interval: monthly
-  open-pull-requests-limit: 1
 
 # A monthly update to rust dependencies. These will be grouped,
 # e.g. one PR will contains updates for all dependencies.
@@ -14,7 +17,6 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
-  open-pull-requests-limit: 1
   # Make it also update transitive dependencies in Cargo.lock
   allow:
     - dependency-type: "all"

--- a/dependabot-weekly.yml
+++ b/dependabot-weekly.yml
@@ -1,13 +1,16 @@
 version: 2
 updates:
 
+# We do not set open-pull-requests-limit, as sometimes
+# dependabot thinks the limit is hit without actually having
+# any PRs open. In reality, the configs below can only result
+# in at most one PR per package ecosyste manyway.
 # A weekly update of the rust-vmm-ci submodule
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
     interval: weekly
     day: monday
-  open-pull-requests-limit: 1
 
 # A weekly update to rust dependencies. These will be grouped,
 # e.g. one PR will contains updates for all dependencies.
@@ -16,7 +19,6 @@ updates:
   schedule:
     interval: weekly
     day: monday
-  open-pull-requests-limit: 1
   # Make it also update transitive dependencies in Cargo.lock
   allow:
     - dependency-type: "all"


### PR DESCRIPTION
There seems to be a bug in dependabot where sometimes it refuses to open PRs due to hitting the pull request limit despite no PRs being open. The rust-vmm/kvm repository ran into this. To avoid this in the future, drop the open-pull-requests-limit key, which fixed the issue for rust-vmm/kvm. In practice, due to us only having a single submodule and due to cargo updates being grouped, we can only get at most one PR per ecosystem at a time anyway.

See also https://github.com/rust-vmm/kvm/pull/336

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
