### PR TITLE
small fixups to cargo-all-features

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -5,7 +5,13 @@
       "command": "RUSTFLAGS=\"-D warnings\" cargo all-features build --release --workspace --all-targets",
       "platform": [
         "x86_64",
-        "aarch64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "build-gnu",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo build --all-features --release --workspace --all-targets",
+      "platform": [
         "riscv64"
       ]
     },
@@ -30,7 +36,16 @@
       "command": "cargo all-features test --workspace",
       "platform": [
         "x86_64",
-        "aarch64",
+        "aarch64"
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
+    },
+    {
+      "test_name": "unittests-gnu",
+      "command": "cargo test --all-features --workspace",
+      "platform": [
         "riscv64"
       ],
       "docker_plugin": {
@@ -53,7 +68,16 @@
       "command": "cargo all-features test --release --workspace",
       "platform": [
         "x86_64",
-        "aarch64",
+        "aarch64"
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
+    },
+    {
+      "test_name": "unittests-gnu-release",
+      "command": "cargo test --all-features --release --workspace",
+      "platform": [
         "riscv64"
       ],
       "docker_plugin": {
@@ -76,7 +100,13 @@
       "command": "cargo all-features clippy --workspace --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks",
       "platform": [
         "x86_64",
-        "aarch64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "clippy",
+      "command": "cargo clippy --all-features --workspace --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "platform": [
         "riscv64"
       ]
     },


### PR DESCRIPTION
- Turns out any cargo subcommand can be ran like this, instead of just the ones documented on the cargo-all-features crates.io page, so run clippy like this as well
- convert one last forgotten step (unittests-gnu)
- revert riscv64 tests back to using --all-features, as compiling multiple permutations is simply too slow in the emulated environment :(

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
