### PR TITLE
ci: add --cfg for cargo doc to disable compile_error!()

### DIFF
--- a/.buildkite/test_description.json
+++ b/.buildkite/test_description.json
@@ -29,7 +29,7 @@
     },
     {
       "test_name": "doc",
-      "command": "RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --all-features --no-deps"
+      "command": "RUSTDOCFLAGS=\"-D warnings\" RUSTFLAGS=\"--cfg RUTSDOC_disable_feature_compat_errors\" cargo doc --workspace --all-features --no-deps"
     },
     {
       "test_name": "unittests-gnu",


### PR DESCRIPTION
Some crates, such as vhost, use compile_error!() to indicate that mutually exclusive feature have been specified. This leads to problems when running cargo doc --all-features, which will inevitably trigger these conditions and then lead to documentation not building (for this reason, the vhost documentation currently fails to build on docs.rs for example).

Add a custom cfg that gets passed via RUSTFLAGS in the cargo doc CI step on whose absense these compile_error!() macros can be gated, so that they dont cause issues when building documentation in CI

See also rust-vmm/vhost#326

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
