### PR TITLE
add s390x CI

### DIFF
--- a/.platform
+++ b/.platform
@@ -1,3 +1,4 @@
 x86_64
 aarch64
 riscv64
+s390x

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ The [Buildkite](https://buildkite.com) pipeline is the definition of tests to
 be run as part of the CI. It includes steps for running unit tests and linters
 (including coding style checks), and computing the coverage.
 
-Currently the tests can run on Linux `x86_64`, `aarch64` and `riscv64`
-(virtualized inside QEMU) hosts. Which hosts tests should be ran for is
+Currently the tests can run on Linux `x86_64`, `aarch64` and (virtualized inside QEMU)
+`riscv64` and `s390x` hosts. Which hosts tests should be ran for is
 determined by the `.platform` file in the repository root.
 
 Example of step that checks the build:

--- a/setup_repository.sh
+++ b/setup_repository.sh
@@ -14,7 +14,7 @@ EOF
 
 RUST_VMM_CI=$(dirname ${BASH_SOURCE[0]})
 
-SUPPORTED_PLATFORMS=("x86_64" "aarch64" "riscv64")
+SUPPORTED_PLATFORMS=("x86_64" "aarch64" "riscv64" "s390x")
 PLATFORMS_FILE=".platform"
 
 DEPENDABOT_SCHEDULES=("weekly" "monthly")


### PR DESCRIPTION
### Summary of the PR

look at this two PRs for more context:

https://github.com/rust-vmm/rust-vmm-container/pull/145
https://github.com/rust-vmm/seccompiler/pull/97

I would like to get seccompiler on s390x. therefore I need an CI on s390x. I already setup the PR for the container. As soon as its merged I can update the tag here and get s390x support in the CI. 


I added `s390x` to every step that is run on `riscv`. However as  I currently only want seccompiler I think this is actually not needed. 

### Requirements


- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
