### PR TITLE
allow tests to define if_changed and crate_path

### DIFF
--- a/.buildkite/autogenerate_pipeline.py
+++ b/.buildkite/autogenerate_pipeline.py
@@ -356,7 +356,13 @@ class BuildkiteConfig:
             step_input = copy.deepcopy(test)
             step_input["platform"] = platform
             step_input["crate"] = crate
-            step_input["crate_path"] = crate_path
+            # We always allow the test description to overwrite global configurations.
+            # To do so, we first check if the test definition has a `crate_path`, if yes, we use that. Otherwise, we
+            # use the passed parameter `crate_path`. This also applies to "if_changed".
+            crate_path = test.get("crate_path", crate_path)
+            if crate_path is not None:
+                step_input["crate_path"] = crate_path
+            if_changed = test.get("if_changed", if_changed)
             if if_changed is not None:
                 step_input["if_changed"] = if_changed
             if not step_input.get("hypervisor"):


### PR DESCRIPTION
### Summary of the PR

We now check whether the test defines if_changed and crate_path before using the ones from the workspace. If the tests does define these two, then we don't overwrite them with the default workspace configuration.

This is needed so that custom pipelines for tests can specify as if changed the crate that they're intended to. Without this change we end up running the custom tests for all crates that are changed instead of running it just for the crate that they're intended.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
